### PR TITLE
Added timeout option (Enabled by default)

### DIFF
--- a/src/yaral.ts
+++ b/src/yaral.ts
@@ -1,5 +1,4 @@
 const Limitus = require('limitus');
-
 import { Bucket } from './bucket';
 import { tooManyRequests, Output } from 'boom';
 import { Server, Request, Response, PluginFunction, ServerRequestExtPoints } from 'hapi';


### PR DESCRIPTION
Notes:

- Per @connor4312 : Timeout should be enabled by default with a value of 1000ms

- In case we have RedisTimeoutError, we continue normally

- Log will be added in a future iteration
 
-  The mixer config will be passed through the register options from backend: https://github.com/mixer/backend/pull/1729